### PR TITLE
models building

### DIFF
--- a/app/Models/Club.php
+++ b/app/Models/Club.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Club extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Matche.php
+++ b/app/Models/Matche.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Matche extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    use HasFactory;
+}


### PR DESCRIPTION
Se crea rama de funcionalidad para generar los modelos. En este caso concreto, la creación de modelos ha sido una tarea muy corta, por lo que no era estrictamente necesario crear una rama de desarollo específica para ello, pero me ha parecido correcto crearla ya que el manejo de modelos en sí, en términos generales, es suficiente complejo como para manejarlo en una rama de desarollo individual. 
Por otro lado, aclarar que para la creación de los modelos se ha seguido la convención de nombrar al modelo con el singular del nombre puesto en las migraciones, a excepción del modelo que maneja los partidos. La migración para partidos se ha nombrado "matches", por lo que si seguía la convención, al modelo debía nombrarlo como "Match", pero Match es una palabra reservada de PHP, así que he nombrado al modelo "Matche", es decir, el nombre de la tabla pero sin 's' final.